### PR TITLE
Re-synchronisation de la hauteur en cas de 0% ou 100%

### DIFF
--- a/core/class/voletProp.class.php
+++ b/core/class/voletProp.class.php
@@ -112,18 +112,18 @@ class voletProp extends eqLogic {
 		$HauteurActuelle=$this->getCmd(null,'hauteur')->execCmd();
 		if($this->getConfiguration('Inverser'))
 			$HauteurActuelle=100-$HauteurActuelle;
-		if($HauteurActuelle == $Hauteur)
-			return;
 		$temps=$this->TpsAction($Hauteur,$HauteurActuelle);
-		if($HauteurActuelle > $Hauteur){
+		if($HauteurActuelle > $Hauteur || $Hauteur=0){
 			$Down->execute(null);
 			log::add('voletProp','debug',$this->getHumanName().' Nous allons descendre le volet à '.$Hauteur.'% depuis '.$HauteurActuelle.'% ('.$temps.'s)');
-		}else{
+		}else if($HauteurActuelle < $Hauteur || $Hauteur=100){
 			$Up->execute(null);
 			log::add('voletProp','debug',$this->getHumanName().' Nous allons monter le volet à '.$Hauteur.'% depuis '.$HauteurActuelle.'% ('.$temps.'s)');
 		}
 		sleep($temps);
-		$Stop->execute(null);
+		// Force les positions de bout de course en ne stoppant pas, pour recuperer des cas de désyncronisation;
+		if ($Hauteur != 0 && $Hauteur != 100)
+			$Stop->execute(null);
 		log::add('voletProp','debug',$this->getHumanName().' Le volet est a '.$Hauteur.'%');
 		if ($this->getConfiguration('cmdMoveState') == '' && $this->getConfiguration('cmdStopState') == '' )			
 			$this->checkAndUpdateCmd('hauteur',$Hauteur);

--- a/desktop/php/voletProp.php
+++ b/desktop/php/voletProp.php
@@ -272,13 +272,23 @@ $eqLogics = eqLogic::byType('voletProp');
 							<legend>Delais</legend>
 							<fieldset>
 								<div class="form-group">
-									<label class="col-sm-2 control-label">{{Temps total}}
+									<label class="col-sm-2 control-label">{{Temps total descente}}
 										<sup>
-											<i class="fa fa-question-circle tooltips" title="{{Saisissez le temps total pour executer une montée ou une decente}}"></i>
+											<i class="fa fa-question-circle tooltips" title="{{Saisissez le temps total pour executer une descente}}"></i>
 										</sup>
 									</label>
 									<div class="col-sm-5">
-										<input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="Ttotal" placeholder="{{Saisir le temps total d'execution (s)}}"/>
+										<input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="TtotalDescente" placeholder="{{Saisir le temps total d'execution (s)}}"/>
+									</div>
+								</div>
+								<div class="form-group">
+									<label class="col-sm-2 control-label">{{Temps total montée}}
+										<sup>
+											<i class="fa fa-question-circle tooltips" title="{{Saisissez le temps total pour executer une montée}}"></i>
+										</sup>
+									</label>
+									<div class="col-sm-5">
+										<input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="TtotalMontee" placeholder="{{Saisir le temps total d'execution (s)}}"/>
 									</div>
 								</div>
 								<div class="form-group">

--- a/docs/fr_FR/index.md
+++ b/docs/fr_FR/index.md
@@ -35,5 +35,6 @@ Objet d'état du volet
 Délais
 ---
 
-* Temps total : Temps total que met le volet pour une fermeture ou un ouverture
+* Temps total descente : Temps total que met le volet pour une fermeture
+* Temps total montée : Temps total que met le volet pour une ouverture
 * Temps de décollement : Temps avant lequel le volet se decolle du sol

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -3,7 +3,7 @@
 	"name" : "Volet proportionel",
 	"description" : "Ce plugin gère l'ouverture et la fermeture proportionnel de nos volet",
 	"licence" : "AGPL",
-	"author" : "Halbout Michael",
+	"author" : "Halbout Michael, Bastien Jacquet",
 	"require" : "2.4",
 	"category" : "automatisation",
 	"hasOwnDeamon" : true,


### PR DESCRIPTION
Améliore la gestion en garantissant les états 0% et 100%, quelque soit l'état de départ (y compris états désynchronisés): On ne stoppe pas le volet du tout dans ce cas.

Ce commit corrige deux cas:
- le cas où le volet fatigue ou a été bloqué et n'est pas physiquement à 100% malgré un ordre de 100%
- le cas où une télécommande autre a commandé le volet sans que Jeedom le sache (ça m'arrive avec mes Volets Somfy RTS). Si Jeedom croit que le volet est à 100 alors qu'il est à 0 en vrai, impossible de le bouger via une commande de position (ni à 100, ni 0).

@mika-nt28, je suis pas sûr que ce soit valide pour tout le monde comme idée. Est-ce que, pour certains volets, on veut TOUJOURS envoyer un STOP en fin de mouvement ?
